### PR TITLE
HV 03_23-35 Jodhpur

### DIFF
--- a/haravijaya/all/hv-all-jodhpur.xml
+++ b/haravijaya/all/hv-all-jodhpur.xml
@@ -1039,62 +1039,69 @@ sargaḥ|
   ahṛta<!--XXX|XXX--> kuṭṭumitena<!--XXX|XXX--> bhṛśaṃ<!--XXX|XXX--> manaḥ<!--XXX|XXX--></l>
 <l>taralaloca<lb/>nanirjitavisphuratkuvalayā<!--XXX|XXX--> valayāvaliśobhinī<!--XXX|XXX--> 22</l>
 </lg>
-<!--
 <lg type="verse" xml:id="HV_03_23">
-<l>smarasakhasya padaṃ surabheriva stanavatī dadhatī samamīmanat|</l>
-<l>alakadeśaniveśaparisphurannavayavāvayavābharaṇaśriyam||23||</l>
+<l>smarasakhasya<!--XXX|XXX--> padaṃ<!--XXX|XXX--> surabher<!--XXX|i XXX--> iva<!--XXX|XXX--> stanavatī<!--XXX|XXX--> dadhatī<!--XXX|XXX--> samamīma<pb n="36"/>nat<!--XXX|XXX--></l>
+<l>alakade<add rend="arrows" place="above line">śaniveśa</add><!--different scribe?-->parisphurannavayavā<add rend="arrows" place="above line">vayavā</add>bharaṇāṃ<!--XXX|XXX--> śriyam<!--XXX|XXX--> 23</l>
 </lg>
 <lg type="verse" xml:id="HV_03_24">
-<l>vidadhataḥ pathikakṣapaṇaṃ prati smṛtibhuvo nijaśaktyupabṛṃhaṇam|</l>
-<l>dadhurahāryataṭāḥ sahakāritāmanavamā navamādhavasaṅginaḥ||24||</l>
+<l>vi<lb/>dadhataḥ<!--XXX|XXX--> pathi<subst>k<del rend="white correction fluid applied">ā</del><add>a</add></subst>kṣapa<subst><del rend="white correction fluid applied">ra</del><add>ṇa</add></subst>ṃ<!--XXX|XXX--> prati<!--XXX|XXX-->
+  smṛtibhuvo<!--XXX|XXX--> nijaśaktyu<lb/>pavṛṃhaṇam<!--XXX|XXX--></l>
+<l>dadhur<!--XXX|'XXX--> ahāryata<subst><del rend="white correction fluid applied">ṭh</del><add>ṭ</add>ā</subst>s<!--XXX|XXX--> sahakāritām<!--XXX|'XXX--> anavamā na<lb/>vamādhavasaṃginaḥ<!--XXX|'XXX--> 24</l>
 </lg>
 <lg type="verse" xml:id="HV_03_25">
-<l>alibhirañjanabindumalīmasaiḥ smarabalairiva kaṅkaṭitairvṛte|</l>
-<l>maruti saurabhaśālini nābhavansarati ke ratikelirasākulāḥ||25||</l>
+<l>alibhir<!--XXX|'XXX--> aṃ<add place="above line">ja</add>naviṃdumalīmasaiḥ<!--XXX|XXX--> <lb/>smarabalair<!--XXX|XXX--> iva<!--XXX|XXX--> kaṅkaṭibhir<!--XXX|XXX--> vṛte<!--XXX|XXX--></l>
+<l>maruti<!--XXX|XXX--> saurabhaśāli<lb/>ni<!--XXX|XXX--> nā<!--XXX|XXX--><del rend="white correction fluid applied"><!--XXX'XXX--></del>bhavan<!--XXX|XXX--> sarati<!--XXX|XXX--> ke<!--XXX|XXX--> ratikelirasākulāḥ<!--XXX|XXX--> 25</l>
 </lg>
 <lg type="verse" xml:id="HV_03_26">
-<l>vikacapattrapuṭaṃ surabhiśriyaḥ sarasavibhramakāñcanapaṅkajam|</l>
-<l>vyadhita campakam unmadanā vadhū rasakalāsakalālikulāravaiḥ||26||</l>
+<l>vika<lb/>capattrapuṭaṃ<!--XXX|XXX--> surabhiśriyas<!--XXX|XXX--> sarasavibhramakāṃcanapaṃkaja<lb/>m<del rend="white correction fluid applied"><!--XXX|XXX--></del></l>
+<l>vyadhita<!--XXX|XXX--> caṃpakam<!--XXX|u XXX--> unmadanā<!--XXX|XXX--> vadhū<!--XXX|XXX--> rasakalāsakalā<subst>l<del>a</del><add rend="implied">i</add></subst><lb/>ku<subst><del><unclear reason="white correction fluid applied"/></del><add>lā</add></subst>ravaiḥ<!--XXX|XXX--> 25</l>
 </lg>
 <lg type="verse" xml:id="HV_03_27">
-<l>rasabhayopagatāḥ pathikā gṛhān madhukarāñjanacūrṇavaśīkṛtāḥ|</l>
-<l>mumudire parirambhasokhocchvasannijavadhūjavadhūtatanuklamāḥ||27||</l>
+<l>rabhasayo<!--XXX|u XXX-->pagatāḥ<!--XXX|XXX--> pathikā<!--XXX|XXX--> gṛhān<!--XXX|XXX--> madhu<lb/>karāṃjanacūrṇavaśīkṛtāḥ<del rend="white correction fluid applied"><!--XXX|XXX--></del></l>
+<l>mumudire<!--XXX|XXX--> parirambhasukho<lb/>cchvasannijavadhūjavadhūtatanuklamāḥ<!--XXX|XXX--> 26</l>
 </lg>
-<pb n="34" />
 <lg type="verse" xml:id="HV_03_28">
-<l>śivapurīmiva śaivalasacchriyaṃ niviśamānamanargalamabjinīm</l>
-<l>bhramarayugmamavekṣya na ka priyairyuvatayo bata yogamupāyayuḥ||28||</l>
+<l>śivapurī<subst>m<!--XXX|i XXX--> <del>a</del><add rend="implied">i</add></subst><lb/>va<!--XXX|XXX--> śaivalasacchriyaṃ<!--XXX|XXX--> niviśamānam<!--XXX|'XXX--> anargalam<!--XXX|'XXX--> <subst><del><unclear reason="white correction fluid applied"/></del><add>abji</add></subst>nīm<!--XXX|XXX--></l>
+<l><lb/>bhramarayugmam<!--XXX|'XXX--> avekṣya<!--XXX|XXX--> na<!--XXX|XXX--> kāḥ<!--XXX|XXX--> priyair<!--XXX|XXX--> yuvatayo<!--XXX|XXX--> vata<!--XXX|XXX--> yogam<!--XXX|u XXX--> u<lb/>pāyayuḥ<!--XXX|XXX--> 27</l>
 </lg>
 <lg type="verse" xml:id="HV_03_29">
-<l>madhukarāñjanabindumanoramaprakaṭapattralatābharaṇojjvalāḥ|</l>
-<l>na surabhāvabhavannatimuktakavratatayo tatayogaguṇaśriyaḥ||29||</l>
+<l>madhukarāñjanaviṃdumanoramaprakaṭapattrala<lb/>tābharaṇojjvalāḥ<!--XXX|XXX--></l>
+<l>na<!--XXX|XXX--> surabhāv<!--XXX|'XXX--> abhava<del rend="white correction fluid applied"><!--XXX|XXX--></del>nn<!--XXX|'XXX--> <subst><del rend="white correction fluid applied">u</del><add rend="implied">a</add></subst>timuktakavratata<pb n="37"/>yo<!--XXX|'XXX-->
+  tatayogaguṇaśriyaḥ<!--XXX|XXX--> 28</l>
 </lg>
 <lg type="verse" xml:id="HV_03_30">
-<l>mukhanilīnaśilīmukhacūcukaṃ kamalinīmukulamburuhastanam|</l>
-<l>adadaratkamiteva na rāgvāndinakaro na karotkarakoṭibhiḥ||30||</l>
+<l>sukhanilīna<subst><del><unclear reason="white correction fluid applied"/></del><add place="above line">śi</add></subst><!--different scribe?-->līmukhacū<lb/>cukaṃ<!--XXX|XXX-->
+  kamalinīmu<subst><del><unclear reason="white correction fluid applied"/></del><add>ku</add></subst>lāmburuhastanam<!--XXX|XXX--></l>
+<l>adadara<add place="above line">ta</add><!--XXX|XXX--> <subst>k<del><unclear reason="white correction fluid applied"/></del><add rend="implied">a</add></subst>mi<lb/>te<!--XXX|i XXX--> va<!--XXX|XXX-->
+  na<!--XXX|XXX--> rāgavān<!--XXX|XXX--> dinakaro<!--XXX|XXX--> na<!--XXX|XXX--> karot<del rend="white correction fluid applied"><!--XXX|XXX--></del>karakoṭibhiḥ<!--XXX|XXX--> 29 <del rend="white correction fluid applied">|</del></l>
 </lg>
 <lg type="verse" xml:id="HV_03_31">
-<l>smaramataṅgajadānajalacchaṭāvipinavāridhividrumavibhrage|</l>
-<l>bhramarasaṃhatirāviravībhavatpracapalā ca palāśatarau śriyam||3||</l>
+<l><lb/>smaramataṅgajadānajalacchaṭāvipinavāridhividruma<lb/>vibhrame<!--XXX|XXX--></l>
+<l>bhramarasaṃhatir<!--XXX|'XXX-->āvirabhībhavat<!--XXX|XXX--> pracapalā<!--XXX|XXX--> ca<!--XXX|XXX--> pa<del rend="white correction fluid applied">|</del><lb/>lāśatarau<!--XXX|XXX--> śriyam<!--XXX|XXX--> 30</l>
 </lg>
 <lg type="verse" xml:id="HV_03_32">
-<l>animiṣākṣivilokitavibhramāṃ surabhimunmanaso navamālikām|</l>
-<l>suravadhūmiva vīkṣya manobhuvo 'navaśamā vaśamāśu madhau yayuḥ||32||</l>
+<l>animiṣākṣivi<subst>l<del>a</del><add rend="implied">o</add></subst>kitavi<lb/>bhramāṃ<!--XXX|XXX--> surabhim<!--XXX|XXX--> unmanaso<!--XXX|XXX--> navamālikām<!--XXX|XXX--></l>
+<l>suravadhū<lb/>m<!--XXX|XXX--> iva<!--XXX|XXX--> vīkṣya<!--XXX|XXX--> manobhuvo<!--XXX|XXX--> 'navaśamā<!--XXX|XXX--> vaśam<!--XXX|''XXX--> āśu<!--XXX|XXX--> madhau<!--XXX|XXX--> yayuḥ<!--XXX|XXX--> <lb/>31</l>
 </lg>
 <lg type="verse" xml:id="HV_03_33">
-<l>suparimṛṣṭakapolatalasphuranmaṇikarālitakāñcanakuṇḍalaḥ|</l>
-<l>na khalua bhīrujano 'nvabhavanmadhau na samado 'samadolanavibhramam||33||</l>
+<l>aparimṛṣṭakapo<subst>l<del rend="white correction fluid applied">e</del><add rend="implied">a</add></subst>talasphura<!---->nma<!--different scribe?-->ṇikarālitakāṃ<lb/>canakuṃḍalaḥ<!--XXX|XXX--></l>
+<l><!--dot/gap?--><subst>n<del rend="white correction fluid applied">u</del><add rend="implied">a</add></subst><!--XXX|XXX--> khalu<!--XXX|XXX--><!--different scribe?-->
+  bhīrujano<!--XXX|'XXX--> '<subst><del><unclear reason="white correction fluid applied"/></del><add>nu</add></subst>bhavan<!--XXX|XXX--> madhau<!--XXX|XXX--> na<!--XXX|XXX-->
+  sama<lb/>do<!--XXX|'XXX--> 'samadolanavibhramam<!--XXX|XXX--> 32</l>
 </lg>
 <lg type="verse" xml:id="HV_03_34">
-<l>smaramadīdipadūrdhvavilocanaṃ purariporiva yacchikhipiṅgalam|</l>
-<l>sphuṭadaśokamudīkṣya tadutsukā na kamitā kamitāramalaṃ vadhūḥ||34||</l>
+<l>smaram<!--XXX|'XXX--> adī<!--different scribe?--><subst><del><unclear reason="white correction fluid applied"/></del><add>di</add></subst>pad<!--XXX|XXX--> ū<subst><del rend="white correction fluid applied"><gap reason="illegible"/></del><add>rdhva</add></subst>ꣻ<lb/>vilocanaṃ<!--XXX|XXX-->
+  purari<subst>p<del rend="white correction fluid applied">au</del><add rend="implied">o</add></subst>r<!--XXX|XXX--> iva<!--XXX|XXX--> yacchikhipiṃgalam<!--XXX|XXX--></l>
+<l>sphu<lb/>ṭad<!--XXX|'XXX--> aśokam<!--XXX|'XXX--> ave<subst>kṣ<del><unclear reason="white correction fluid applied"/></del><add>ya</add></subst> tad<!--XXX|XXX--> utsukā<!--XXX|XXX--> na<!--XXX|XXX-->
+  ka<!--XXX|XXX-->m<!--XXX i XXX--> itā<!--XXX|XXX--> kamitāram<!--XXX|'XXX--> alaṃ<!--XXX|XXX--> <lb/>vadhūḥ<!--XXX|XXX--> 33</l>
 </lg>
-<pb n="35" />
 <lg type="verse" xml:id="HV_03_35">
-<l>vidhutapakṣmarajaḥ kapiśabhramabhramarasaṃhatimabjamukhāśriyam|</l>
-<l>sacaṭulātilakāmiva padminī ghanarasa narasārthahṛdā dadhau||35||</l>
+<l>vidhutapakṣarajaḥ kapiśabhramadbhramarasaṃhatim<!--XXX|'XXX--> a<lb/>bjasukhaśriyam<!--XXX|XXX--></l>
+<l><subst><del rend="white correction fluid applied">ma</del><add rend="stroke on akṣara">sa</add></subst>caṭulā<!--different scribe?-->tilakām<!--XXX|i XXX--> iva<!--XXX|XXX--> padminī<!--XXX|XXX--> gha<del rend="white correction fluid applied"><gap reason="illegible"/></del><pb n="37"/>narasā<!--XXX|XXX-->
+  narasārthahṛdā<!--XXX|XXX--> dadhau<!--XXX|XXX--> 34||</l>
 </lg>
-<p xml:id="HV_03_35p">[iti vasantaḥ]</p>
+<p xml:id="HV_03_35p">vasantaḥ||</p>
+<!--
 <lg type="verse" xml:id="HV_03_36">
 <l>śucidināgatirāplutiśītalāḥ sarasacandanapaṅkabhṛto 'karot|</l>
 <l>priyasakhīva vataṃsitamallikāḥ stanavatīrnavatīvratanuklamāḥ||36||</l>
@@ -1355,7 +1362,7 @@ tṛtīyaḥ sargaḥ|
 </p>
 -->
 <p xml:id="HVVU_03_1"><lb n="b1"/>atha sa devo mandarācale girijayā<!--XXX'XXX-->valambito yugapad eva sarvartubhir a<!--XXX'XXX-->sevya<lb n="b2"/>ta prasavāḥ kusumāni arīṇāṃ vijetṛtvād a<!--XXX'XXX-->naghā acchadmacāriṇo <!--XXX'XXX--><lb n="b3"/>pratihatā vā bhujataravo yasya saḥ 1 </p>
-<p xml:id="HVVU_03_2">madhupānāṃ rājibhiḥ parājitamana<lb n="b4"/>svinīmanasaḥ sumanasaḥ puṣpāṇi yatra tādṛśaṃ jagat surabher vasanta<lb n="b5"/>sya śobhām a<!--XXX'XXX-->vahat sumanobhiḥ surabhi sāmodaṃ jagat śriyaṃ dadhre i<lb n="b6"/>ti vā yojanā viplavo bādhaḥ sphuṭitāni bhinnāni tatāni āmra<lb n="b7"/>vaṇāni yatra 2 </p> 
+<p xml:id="HVVU_03_2">madhupānāṃ rājibhiḥ parājitamana<lb n="b4"/>svinīmanasaḥ sumanasaḥ puṣpāṇi yatra tādṛśaṃ jagat surabher vasanta<lb n="b5"/>sya śobhām a<!--XXX'XXX-->vahat sumanobhiḥ surabhi sāmodaṃ jagat śriyaṃ dadhre i<lb n="b6"/>ti vā yojanā viplavo bādhaḥ sphuṭitāni bhinnāni tatāni āmra<lb n="b7"/>vaṇāni yatra 2 </p>
 <p xml:id="HVVU_03_3">yamena sevitā dig dakṣiṇā tām a<!--XXX'XXX-->pāsya raviḥ aiḍa<lb n="b8"/>biḍo dhanadaḥ āśrayaḥ patir yasyāstāṃ diśam uttarām aśiśriyat <lb n="b9"/>sevitavān utkatā<!--XXX'XXX-->nurāgas teneva utsuko hi kāmītayā yameneva <lb n="b10"/>kenacid a<!--XXX'XXX-->dhiṣṭhitāṃ yuvatim utsṛjya kasyacid a<!--XXX'XXX-->rtheśvarasya ramaṇīṃ pra<lb n="b11"/>tipadyate asumatāṃ prāṇināṃ sumatām a<!--XXX'XXX-->tīva śītoṣṇayor a<!--XXX'XXX-->bhāvā<lb n="b12"/>d a<!--XXX'XXX-->tyantarucitām 3</p>
 <p xml:id="HVVU_03_4"><pb n="33"/>tilakais tarubhedair ujjvalapattrābhiś ca latābhiḥ sahavartamānā giribhuvo ra<lb n="b2"/>myāṃ sthitim a<!--XXX'XXX-->dhārayan vanāni jalāni kānanāni vā tilakaś cittra<lb n="b3"/>kaḥ pattralatāḥ pattrabhaṃgāḥ tatsahitāś ca kāminyo manoharasthitayaḥ <lb n="b4"/>vanānām a<!--XXX'XXX-->tra kāmitā pratīyate samāsoktivaśāt 4</p>
 <p xml:id="HVVU_03_5">rucir a<!--XXX'XXX-->bhilā<lb n="b5"/>ṣaḥ kāntiś ca madhuḥ puṣparaso madhuś ca vasantaḥ avatīrṇamanobhavatvāt pa<lb n="b6"/>ravatīḥ parataṃtrāḥ madhuliho bhramarāḥ 5</p>
@@ -1371,7 +1378,7 @@ tṛtīyaḥ sargaḥ|
 <p xml:id="HVVU_03_16">caramaḥ paścimaḥ | saṃpuṭo dvayam | anugiraṃ girisamīpe | ‘gireśca senakasya’ iti ṭac | rase madhuni mano yasya saḥ | samanādaṃ tulyadhvaniṃ kṛtvā ||16||</p>
 <p xml:id="HVVU_03_17">17||</p>
 <p xml:id="HVVU_03_18"> kusumam eva koṣaś caṣakaṃ tam eva taror nāyakabhūtasyārpayituṃ latā vivalitā saṃmukhaṃ parivṛttā | madhu makarandaḥ surā ca | balī haladharaḥ | tāpaḥ kāmajvaro 'pi ||18||</p>
-<p xml:id="HVVU_03_19">kesarāṇi bakulāny eva | ketūnāṃ dhvajānāṃ śatāni yasmin || 19 ||</p> 
+<p xml:id="HVVU_03_19">kesarāṇi bakulāny eva | ketūnāṃ dhvajānāṃ śatāni yasmin || 19 ||</p>
 <p xml:id="HVVU_03_20">madhor vasantasya saṃgamān niśayā mukhe prārambhe kaluṣatā nāpi na prāptā | tadā diśām atiśayena vaiśadyāt | aniśaṃ sadā yāpitam ativāhitaṃ mānaṃ parimāṇaṃ dairghyaṃ yayā | vasante rātrīṇāṃ tānavotpatteḥ | kāminī dvitīyakāminyā kṛtaśamanavighnatvāc cireṇāpi samāgate preyasi na vadane kāluṣyam āpnoti madyasaṃparkāt | madhu madyamapi | māno 'bhimāno 'pi || 20|| </p>
 <p xml:id="HVVU_03_21">sarasijānāmurasimadhye bhramarair joṣam avasthitaṃ sukhaṃ viśrāntam | uttaracchadaḥ pracchadapaṭaḥ | sajānibhiḥ sabhāryaiḥ | ‘jāyāyā niṅ’ || 21 || </p>
 <p xml:id="HVVU_03_22">kuṭṭamitākhyena ceṣṭitena manaḥ kāntasya vadhūr ahṛta samāvarjayat | ‘prāṇeśagāḍhabhujapāśanipīḍitānām uddāmaharṣabharanirbharamānasānām | hī duḥkhayasy alam alaṃ dṛḍhamūḍhavākyaiḥ saukhye 'pi duḥkha iva kuṭṭamitaṃ vadanti’ || 22 || </p>
@@ -1407,7 +1414,7 @@ tṛtīyaḥ sargaḥ|
 <p xml:id="HVVU_03_52">atanoḥ kāmasya bahulāyāś ca śriya ālayatvaṃ kalayatā gṛhṇatā kuṭajākhyakusumanicayena nakṣatragaṇavad ācaritam | nabhasi śrāvaṇe 'ntarikṣe ca | candrākārair dalaiḥ pallavaiḥ, candrasya ca dalena khaṇḍenojjvale rucire || 52 || </p>
 <p xml:id="HVVU_03_53">vāri vikira jalaṃ vikiran ityādikam ācaran jalado viyutāṃ viyoginīṃ na navaśām, api tv āyattām eva cakāra | vikiretyādau ‘samuccaye 'nyatarasyām’ iti loṭ | hirādeśaś ca | ācaran iti sāmānyavacanasyānuprayogaḥ ‘samuccaye sāmānyavacanasya’ iti || 53 || </p>
 <p xml:id="HVVU_03_54">nigūhanena sthitimataḥ sukhitān ittham iva ravais taruṇānambudo 'bhyadhyāt | abhimato 'tīvābhipretaḥ | samāgamakāraṇatvāt ||54 || </p>
-<p xml:id="HVVU_03_55">55 ||</p> 
+<p xml:id="HVVU_03_55">55 ||</p>
 <p xml:id="HVVU_03_56">alātam ulmukam | tatsadṛśī taḍid āvirabhavat prakaṭībabhūva | samavartī yamaḥ ||56|| </p>
 <p xml:id="HVVU_03_57">āmalais tarubhedaiḥ kandalaiś ca latāviśeṣaiḥ satī śobhanā śrīr yāsām | amalaiś ca kandair bisair anyair vā mūlair lasantī śrīr yāsām | girimallikā kuṭajam | tacchabalitatvād bhramarair valitā veṣṭitāḥ || 57 || </p>
 <p xml:id="HVVU_03_58">navo dhūrgataś ca paradhārādhirūḍhaḥ kāmo yāsāṃ tathāvidhā vadhūrabhrapavanaś cakāraiva | kuṭajādayo vārṣikāḥ kusumaviśeṣāḥ || 58 || </p>


### PR DESCRIPTION
HV_03_24: <subst><del rend="white correction fluid applied">ṭh</del><add>ṭ</add>ā</subst>s - Will that work?

HV_03_33: There are some problems here. The nma in °sphuranmaṇi° seems to be inserted by a different hand. Then, there is a little dot at the beginning of pada c before "na khalu". It seems to me that maybe the "original" scribe put a piece of rekhā there then left a gap to be filled out later (na khalu also seems to be written by someone else) and continued the rekhā on the bh of bhīrujano. How would that be encoded properly? Would that be metamark or space or gap?

HV_03_35: <pb n="37"/> has to be <pb n="38"/> of course. Sorry for that. I'll take care of it in my next commit.